### PR TITLE
Minor fix to test and evaluation of eval_type

### DIFF
--- a/bayes_optim/base.py
+++ b/bayes_optim/base.py
@@ -608,7 +608,10 @@ class baseBO(ABC):
             func_vals = self.parallel_obj_fun(X)
         else:
             if self.n_job > 1: # or by ourselves..
-                func_vals = Parallel(n_jobs=self.n_job)(delayed(self.obj_fun)(x) for x in X)
+                if self._eval_type == 'dataframe':
+                    func_vals = Parallel(n_jobs=self.n_job)(delayed(self.obj_fun)(x) for _, x in X.iterrows())
+                else:
+                    func_vals = Parallel(n_jobs=self.n_job)(delayed(self.obj_fun)(x) for x in X)
             else:              # or sequential execution
                 func_vals = [self.obj_fun(x) for x in X]
 


### PR DESCRIPTION
This fixed #11 by explicitly changing the objective function to meet the eval_type setting.
It also updates the evaluation function when 'dataframe' is used as eval_type, since normal list comprehension doesn't work for dataframes (replaced by iterrows)